### PR TITLE
feat(editor): wrap long lines

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -67,7 +67,7 @@
 
 @layer base {
   * {
-    @apply border-border;
+    @apply box-border border-border;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/lib/components/Editor/Editor.css
+++ b/src/lib/components/Editor/Editor.css
@@ -1,5 +1,5 @@
 .ql-editor {
-  @apply h-full w-full overflow-y-auto border-none !px-3 !py-2.5 text-base leading-[136%] outline-none duration-100;
+  @apply h-full w-full overflow-y-auto border-none !px-3 !py-2.5 text-base leading-[136%] outline-none duration-300;
 }
 
 .ql-editor,
@@ -8,11 +8,12 @@
   font-size: var(--editor-font-size);
 }
 
-.ql-editor {
+.editor-container {
   scale: var(--editor-zoom);
   width: calc(100% / var(--editor-zoom));
   height: calc(100% / var(--editor-zoom));
   transform-origin: top left;
+  position: relative;
 }
 
 .ql-editor a {
@@ -20,7 +21,35 @@
 }
 
 .ql-editor > * {
-  @apply !pl-0 duration-100;
+  @apply !pl-0 duration-300;
+}
+
+.editor-container[data-line-numbers='true'] .ql-editor {
+  counter-reset: line;
+  --line-no-font-size-factor: 0.8;
+  @apply !pl-0;
+}
+
+.editor-container[data-line-numbers='true'] .ql-editor > * {
+  margin-left: calc(
+    max(var(--line-no-digits-count), 3) * 1em * var(--line-no-font-size-factor)
+  ) !important;
+  padding-left: calc(var(--editor-font-size) * 0.5) !important;
+  @apply relative border-l-2 border-muted duration-300;
+}
+
+.editor-container[data-line-numbers='true'] .ql-editor > *::before {
+  font-size: calc(var(--editor-font-size) * var(--line-no-font-size-factor));
+  counter-increment: line;
+  content: counter(line);
+  width: calc(max(var(--line-no-digits-count), 3) * 1em) !important;
+  transform: translateX(0);
+  /* padding: 0 1em; */
+  @apply absolute left-0 top-0 -translate-x-full text-center text-primary duration-300;
+}
+
+.editor-container[data-wrap-long-lines='true'] .ql-editor > * {
+  @apply w-max;
 }
 
 @keyframes blink {

--- a/src/lib/components/EditorTabs.svelte
+++ b/src/lib/components/EditorTabs.svelte
@@ -6,7 +6,6 @@
   import { activeTabId, editors } from '@/store/store';
   import { Notpad } from '@/helpers/notpad';
   import { slide } from 'svelte/transition';
-  import { cn } from '@/utils';
 
   let innerWidth = $state(window.innerWidth);
 
@@ -32,10 +31,7 @@
             <div
               role="button"
               tabindex="0"
-              class={cn(
-                'flex items-center justify-center',
-                $activeTabId === editor.id ? 'bg-background' : 'bg-secondary'
-              )}
+              class="flex items-center justify-center"
               onclick={() => ($activeTabId = editor.id)}
               onkeydown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -32,7 +32,7 @@
 
 <svelte:window bind:innerWidth />
 
-<Menubar.Root class="relative z-10 rounded-none">
+<Menubar.Root class="relative z-10">
   <Menubar.Menu>
     <Menubar.Trigger>File</Menubar.Trigger>
     <Menubar.Content>
@@ -137,6 +137,12 @@
         onclick={Notpad.viewOptions.toggleLineNumbers}
       >
         Line Numbers
+      </Menubar.CheckboxItem>
+      <Menubar.CheckboxItem
+        checked={$settings.wrapLongLines}
+        onclick={Notpad.viewOptions.toggleWrapLongLines}
+      >
+        Wrap Long Lines
       </Menubar.CheckboxItem>
       <Menubar.CheckboxItem checked={$mode == 'dark'} onclick={toggleMode}>
         Dark Mode

--- a/src/lib/helpers/menubar/view-options.ts
+++ b/src/lib/helpers/menubar/view-options.ts
@@ -13,6 +13,11 @@ export class ViewOptions {
     settings.update((value) => ({ ...value, lineNumbers: !get(settings).lineNumbers }));
   }
 
+  public toggleWrapLongLines() {
+    Notpad.editors.focus();
+    settings.update((value) => ({ ...value, wrapLongLines: !get(settings).wrapLongLines }));
+  }
+
   public zoom(zoom: 'in' | 'out' | 'reset') {
     const zoomSettings = get(settings).zoom;
     const zoomLevels: SettingsType['zoom'][] = [0.5, 0.75, 0.9, 1, 1.2, 1.5, 1.75, 2];

--- a/src/lib/helpers/rich-text-editor.ts
+++ b/src/lib/helpers/rich-text-editor.ts
@@ -1,0 +1,37 @@
+import Quill from 'quill';
+
+export class RichTextEditor {
+  editorContainer: HTMLElement;
+  quill: Quill;
+
+  constructor({ editorContainer }: { editorContainer: HTMLElement }) {
+    this.editorContainer = editorContainer;
+    const options = {
+      formats: [
+        'bold',
+        'code',
+        'italic',
+        'link',
+        'size',
+        'strike',
+        'script',
+        'underline',
+        'blockquote',
+        'header',
+        'indent',
+        'list',
+        'align',
+        'direction',
+        'code-block',
+        'formula'
+        // 'background',
+        // 'font',
+        // 'image',
+        // 'video'
+      ]
+    };
+
+    this.quill = new Quill(this.editorContainer!, options);
+    return this;
+  }
+}

--- a/src/lib/helpers/settings.ts
+++ b/src/lib/helpers/settings.ts
@@ -7,7 +7,8 @@ export class Settings {
     statusBar: true,
     fontFamily: FontFamily.SUSE,
     fontSize: FontSize.Size16,
-    lineNumbers: false
+    lineNumbers: false,
+    wrapLongLines: false
   };
 
   setFontFamily(fontFamily: FontFamily) {

--- a/src/lib/types/SettingsTypes.ts
+++ b/src/lib/types/SettingsTypes.ts
@@ -56,4 +56,8 @@ export interface SettingsType {
    * The font size of the editor.
    */
   fontSize: FontSize;
+  /**
+   * Should wrap long lines.
+   */
+  wrapLongLines: boolean;
 }


### PR DESCRIPTION
- Added `box-border` class to base layer for better border styling
- Adjusted `duration` property for `ql-editor` class in Editor.css
- Added `position: relative` to `.editor-container` class in Editor.css
- Added line numbers functionality to the editor container
- Updated styles for line numbers in Editor.css
- Added wrap long lines functionality to the editor container
- Updated Menubar component to include "Wrap Long Lines" checkbox
- Added `wrapLongLines` property to settings
- Created RichTextEditor class to handle Quill initialization
