### PR TITLE
fix: resolve `onMount` lifecycle issue in iOS Safari by reordering layout structure

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,15 +23,14 @@
 
 <DynamicFavicon />
 
+<div class="flex h-full flex-col">
+  <MenuBar />
+  <EditorTabs />
+</div>
+
 {#if isLoading}
   <Loading />
 {:else}
-  <!-- What user see on initially -->
-  <div class="flex h-full flex-col">
-    <MenuBar />
-    <EditorTabs />
-  </div>
-
   <!-- Components that aren't appear on initial roll -->
   <EditorCloseConfirmationDialog />
   <FontDialog />


### PR DESCRIPTION
### Description
This PR fixes issue #268, where the `onMount` lifecycle hooks in child components (`EditorTabs.svelte` and its child `Editor.svelte`) were not being reliably triggered on iOS Safari. The issue was caused by the main application layout `<div>` being nested within a conditional `isLoading` block, which affected how iOS Safari handled the rendering and mounting of child components.

To address this, the main application layout `<div>` containing the `<EditorTabs />` and `<MenuBar />` has been moved outside of the `isLoading` condition. This ensures that child components are always mounted, regardless of the loading state, allowing their lifecycle hooks to trigger as expected.

### Changes
- Moved the `<div>` containing the main layout (`<MenuBar />` and `<EditorTabs />`) out of the `isLoading` conditional block.
- Preserved the loading behavior by keeping the `<Loading />` component conditional.

### Testing
- **Browsers Tested**:  
  - Windows 11: Chrome, Firefox, Edge 
  - iOS: Safari (Issue confirmed resolved)  

- **Behavior Verified**:
  - Confirmed `onMount` triggers as expected for all child components across all platforms.
  - Verified no regressions in the `isLoading` behavior.

### Fixes
Fixes #268: Problems on iOS devices
and #267: Keyboard does not appear in notpad text area on iOS devices